### PR TITLE
fixes #4 by searching by doi when title fails

### DIFF
--- a/Construct_Models/webscraper.py
+++ b/Construct_Models/webscraper.py
@@ -2,7 +2,7 @@
 """
 Created on Mon Apr 15 16:06:04 2019
 
-@author: Gary
+@author: Gary & Ryan
 """
 
 # https://realpython.com/python-web-scraping-practical-introduction/
@@ -14,6 +14,9 @@ import pandas as pd
 import re
 import numpy as np
 import ast
+import os
+
+#os.chdir('E:/Google Drive/Documents/BiomechL_webscraper/literature_update')
 
 def simple_get(url):
     """
@@ -105,7 +108,7 @@ for page in np.arange(1,22):
                 
                 if not titles_temp in titles:
                     authors.append(authors_temp)
-                    titles.append(titles.temp)
+                    titles.append(titles_temp)
                     catagories.append(cur_cat)
                     try:
                         year_nan = entry.find('NaN')
@@ -170,15 +173,107 @@ filtered_data = pd.DataFrame(data =  {'Catagory': [],
                                       'DOI': []})
 
 for cat in cat_lengths.Catagory.unique():
-    filtered_data = pd.concat([filtered_data,data[data.Catagory==cat and data]])
+    if not cat == 'UNIQUETOPIC':
+        filtered_data = pd.concat([filtered_data,data[data.Catagory==cat]])
 
 filtered_data.to_csv('RYANDATA_filt.csv')
 
+#========================= Getting Abstracts ==================================
+from Bio import Entrez
+import numpy as np
+Entrez.api_key = "f3e4ca963cb5371b03e53e49ca9b836f2c08"
 
+def search(query):
+    Entrez.email = 'your.email@example.com'
+    handle = Entrez.esearch(db='pubmed', 
+                            sort='most recent', 
+                            retmax='5000',
+                            retmode='xml', 
+                            reldate = 7, #only within n days from now
+                            term=query)
+    results = Entrez.read(handle)
+    return results
 
+def fetch_details(id_list):
+    ids = ','.join(id_list)
+    Entrez.email = 'your.email@example.com'
+    handle = Entrez.efetch(db='pubmed',
+                           retmode='xml',
+                           id=ids)
+    results = Entrez.read(handle)
+    return results
 
+def search2(query):
+    Entrez.email = 'your.email@example.com'
+    handle = Entrez.esearch(db='pubmed', 
+                            sort='most recent', 
+                            retmax='5000',
+                            retmode='xml', 
+                            term=query)
+    results = Entrez.read(handle)
+    return results
 
+import time
+abstracts = []
 
+def get_abstract(title, doi):
+    paper = search2(title)
+    if paper['IdList'] == []:
+        print('- No Title Match. Searching by DOI')
+        paper = search2(doi.replace('http://dx.doi.org/',''))
+        if paper['IdList'] == []:
+            print('DOI Search Failed')
+    paper = fetch_details(paper['IdList'])
+    return paper['PubmedArticle'][0]['MedlineCitation']['Article']['Abstract']['AbstractText']
+
+from nltk.corpus import stopwords
+
+def clean_str(abs_string,stop):
+    translator = str.maketrans(string.punctuation, ' '*len(string.punctuation)) #map punctuation to space
+    abs_string = abs_string.translate(translator)
+    abs_string = abs_string.split()
+    abs_string = [word for word in abs_string if word not in stop]
+    abs_string = ' '.join(abs_string)
+    return abs_string
+    
+# Make the Stop Words
+import string
+stop = list(stopwords.words('english'))
+stop_c = [string.capwords(word) for word in stop]
+for word in stop_c:
+    stop.append(word)
+new_stop = ['StringElement','NlmCategory','Label','attributes','INTRODUCTION','METHODS','BACKGROUND','RESULTS','CONCLUSIONS']
+for item in new_stop:
+    stop.append(item)
+
+# Pull Abstracts
+abstracts = []
+toc = time.perf_counter()
+tic = time.perf_counter()
+for i, title in enumerate(titles[0:10]):
+#    if i % 100 == 0:
+    print('Analyzing Title: '+ str(i))
+    if toc - tic < .1:
+        time.sleep(.1 - (toc-tic))
+    tic = time.perf_counter()
+    try:
+        abstracts.append(clean_str(str(get_abstract(title, doi[i])),stop))
+    except:
+        abstracts.append([])
+    toc = time.perf_counter()
+
+# %% Test
+    
+#Some papers just don't have an abstact: 
+#titles[9]  = https://www.ncbi.nlm.nih.gov/pubmed/?term=Accumulation+of+microdamage+at+complete+and+incomplete+fracture+sites+in+a+patient+with+bilateral+atypical+femoral+fractures+on+glucocorticoid+and+bisphosphonate+therapy 
+    
+test = get_abstract(titles[84], doi[84])
+test = str(test)
+translator = str.maketrans(string.punctuation, ' '*len(string.punctuation)) #map punctuation to space
+test = test.translate(translator)
+test = test.split()
+test = [word for word in test if word not in stop]
+test = ' '.join(test)
 
 
 


### PR DESCRIPTION
Incorporates current changes to webscraper from gary branch (as of now) to import abstracts. Tested on 10 papers, not the whole database. 